### PR TITLE
Bump lib-http-client to 4.0.0-SNAPSHOT #250

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-lib-http-client = "3.2.2"
+lib-http-client = "4.0.0-SNAPSHOT"
 java-jwt = "4.5.0"
 jwks-rsa = "0.24.0"
 junit-bom = "6.0.3"


### PR DESCRIPTION
Closes #250.

## Summary

XP 8 E2E verification passed — full report on the issue. The only XP-7→XP-8 bump needed is `lib-http-client`: 3.2.2 is XP-7-built; 4.0.0-SNAPSHOT (on `repo.enonic.com/dev`) is the XP 8 cut.

`build.gradle` already declares `xp.enonicRepo('dev')`, so no repo wiring change needed.

## Verification

- `./gradlew build --refresh-dependencies` — green (unit tests included)
- E2E on XP 8.0.0-SNAPSHOT (de1dc52): bundle ACTIVE, autoinit creates idprovider via `SecurityService.createIdProvider`, `/_/idprovider/<key>/{get,logout}` dispatch correctly, no startup errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)