### PR TITLE
Experimental CLI / device login (RFC 8628)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     include xplibs.portal
     include xplibs.cluster
     include xplibs.event
+    include xplibs.grid
 
     include libs.lib.httpclient
     include libs.java.jwt

--- a/src/main/java/com/enonic/app/oidcidprovider/handler/DeviceTokenHandler.java
+++ b/src/main/java/com/enonic/app/oidcidprovider/handler/DeviceTokenHandler.java
@@ -1,6 +1,7 @@
 package com.enonic.app.oidcidprovider.handler;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Arrays;
@@ -83,6 +84,22 @@ public class DeviceTokenHandler
     public String base64UrlDecode( final String value )
     {
         return new String( Base64.getUrlDecoder().decode( value ), StandardCharsets.UTF_8 );
+    }
+
+    /**
+     * Standard Base64 of the SHA-256 of a UTF-8 string, for a CSP {@code 'sha256-...'} source.
+     */
+    public String sha256Base64( final String value )
+    {
+        try
+        {
+            return Base64.getEncoder()
+                .encodeToString( MessageDigest.getInstance( "SHA-256" ).digest( value.getBytes( StandardCharsets.UTF_8 ) ) );
+        }
+        catch ( java.security.NoSuchAlgorithmException e )
+        {
+            throw new IllegalStateException( e );
+        }
     }
 
     public String sign( final String secret, final String kid, final String issuer, final String subject, final String audience,

--- a/src/main/java/com/enonic/app/oidcidprovider/handler/DeviceTokenHandler.java
+++ b/src/main/java/com/enonic/app/oidcidprovider/handler/DeviceTokenHandler.java
@@ -1,0 +1,194 @@
+package com.enonic.app.oidcidprovider.handler;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import com.enonic.app.oidcidprovider.jwt.JwtUtil;
+import com.enonic.app.oidcidprovider.mapper.MapMapper;
+import com.enonic.xp.script.bean.BeanContext;
+import com.enonic.xp.script.bean.ScriptBean;
+import com.enonic.xp.script.serializer.MapSerializable;
+
+/**
+ * Mints and verifies the self-issued device-login access tokens: symmetric (HS512) JWTs following
+ * RFC 9068 ({@code typ=at+jwt}, a {@code kid} header, and the iss/sub/aud/exp/iat/jti/client_id
+ * claims).
+ */
+public class DeviceTokenHandler
+    implements ScriptBean
+{
+    private static final Logger LOG = LoggerFactory.getLogger( DeviceTokenHandler.class );
+
+    private static final String TYP = "at+jwt";
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private static final Base64.Encoder B64URL_NOPAD = Base64.getUrlEncoder().withoutPadding();
+
+    // RFC 8628 section 6.1 recommended user-code character set (no easily confused characters).
+    private static final char[] USER_CODE_ALPHABET = "BCDFGHJKLMNPQRSTVWXZ".toCharArray();
+
+    /**
+     * High-entropy, URL-safe device_code (the secret the client polls with).
+     */
+    public String generateDeviceCode()
+    {
+        final byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes( bytes );
+        return B64URL_NOPAD.encodeToString( bytes );
+    }
+
+    /**
+     * Short, human-enterable user_code, formatted as XXXX-XXXX.
+     */
+    public String generateUserCode()
+    {
+        final StringBuilder sb = new StringBuilder( 9 );
+        for ( int i = 0; i < 8; i++ )
+        {
+            if ( i == 4 )
+            {
+                sb.append( '-' );
+            }
+            sb.append( USER_CODE_ALPHABET[SECURE_RANDOM.nextInt( USER_CODE_ALPHABET.length )] );
+        }
+        return sb.toString();
+    }
+
+    /**
+     * URL-safe Base64 (no padding) of a UTF-8 string.
+     */
+    public String base64UrlEncode( final String value )
+    {
+        return B64URL_NOPAD.encodeToString( value.getBytes( StandardCharsets.UTF_8 ) );
+    }
+
+    /**
+     * Reverses {@link #base64UrlEncode}; throws {@link IllegalArgumentException} on non-Base64 input.
+     */
+    public String base64UrlDecode( final String value )
+    {
+        return new String( Base64.getUrlDecoder().decode( value ), StandardCharsets.UTF_8 );
+    }
+
+    public String sign( final String secret, final String kid, final String issuer, final String subject, final String audience,
+                        final String clientId, final String scope, final int expiresInSeconds )
+    {
+        final Instant now = Instant.now();
+
+        // Optional claims are omitted when empty rather than emitted as empty strings.
+        final com.auth0.jwt.JWTCreator.Builder builder = JWT.create()
+            .withKeyId( kid )
+            .withHeader( java.util.Map.of( "typ", TYP ) )
+            .withIssuer( issuer )
+            .withSubject( subject )
+            .withIssuedAt( now )
+            .withExpiresAt( now.plusSeconds( expiresInSeconds ) )
+            .withJWTId( UUID.randomUUID().toString() );
+
+        final String[] audiences = splitToArray( audience );
+        if ( audiences.length > 0 )
+        {
+            builder.withAudience( audiences );
+        }
+        if ( clientId != null && !clientId.isEmpty() )
+        {
+            builder.withClaim( "client_id", clientId );
+        }
+        if ( scope != null && !scope.isEmpty() )
+        {
+            builder.withClaim( "scope", scope );
+        }
+
+        return builder.sign( Algorithm.HMAC512( secret ) );
+    }
+
+    /**
+     * Verifies a self-issued token: signature (HS512 with the shared secret),
+     * issuer, expiry and audience. The algorithm is pinned to HS512 - the
+     * token header is never trusted to pick the algorithm.
+     *
+     * @return the decoded payload, or {@code null} if verification fails.
+     */
+    public MapSerializable verify( final String token, final String secret, final String issuer, final List<String> allowedAudience )
+    {
+        if ( token == null || secret == null )
+        {
+            return null;
+        }
+
+        try
+        {
+            final DecodedJWT decodedJWT = JWT.require( Algorithm.HMAC512( secret ) )
+                .withIssuer( issuer )
+                .acceptLeeway( 1 )
+                .build()
+                .verify( token );
+
+            if ( allowedAudience != null && !allowedAudience.isEmpty() )
+            {
+                final List<String> audience = decodedJWT.getAudience();
+                final Set<String> intersection = audience == null
+                    ? Set.of()
+                    : audience.stream().filter( allowedAudience::contains ).collect( Collectors.toSet() );
+                if ( intersection.isEmpty() )
+                {
+                    LOG.debug( "Device token rejected: audience {} not in allowed {}", audience, allowedAudience );
+                    return null;
+                }
+            }
+
+            return new MapMapper( JwtUtil.parsePayload( decodedJWT.getPayload() ) );
+        }
+        catch ( Exception e )
+        {
+            LOG.debug( "Failed to verify device token: {}", e.getMessage() );
+            return null;
+        }
+    }
+
+    /**
+     * Decodes the issuer claim of a token <b>without</b> verifying its signature.
+     * Used only to route a bearer token to the correct verifier - never to trust it.
+     */
+    public String peekIssuer( final String token )
+    {
+        try
+        {
+            return JWT.decode( token ).getIssuer();
+        }
+        catch ( Exception e )
+        {
+            return null;
+        }
+    }
+
+    private static String[] splitToArray( final String value )
+    {
+        if ( value == null || value.isBlank() )
+        {
+            return new String[0];
+        }
+        return Arrays.stream( value.trim().split( "\\s+" ) ).filter( s -> !s.isEmpty() ).toArray( String[]::new );
+    }
+
+    @Override
+    public void initialize( final BeanContext context )
+    {
+        // no services required
+    }
+}

--- a/src/main/resources/idprovider/idprovider.js
+++ b/src/main/resources/idprovider/idprovider.js
@@ -221,12 +221,8 @@ exports.autoLogin = function (req) {
 
     const jwtToken = extractJwtToken(req, idProviderConfig);
 
-    if (!jwtToken) {
-        requestLib.autoLoginFailed();
-        return;
-    }
-
-    if (deviceLogin.isSelfIssued(idProviderConfig, jwtToken)) {
+    // Self-issued device-login token: accepted before the JWKS guard, so it works without external JWKS.
+    if (jwtToken && deviceLogin.isSelfIssued(idProviderConfig, jwtToken)) {
         if (!deviceLogin.accept(jwtToken, idProviderConfig)) {
             requestLib.autoLoginFailed();
         }
@@ -234,6 +230,10 @@ exports.autoLogin = function (req) {
     }
 
     if (!idProviderConfig.jwksUri) {
+        return;
+    }
+
+    if (!jwtToken) {
         requestLib.autoLoginFailed();
         return;
     }

--- a/src/main/resources/idprovider/idprovider.js
+++ b/src/main/resources/idprovider/idprovider.js
@@ -6,6 +6,7 @@ const preconditions = require('/lib/preconditions');
 const authLib = require('/lib/xp/auth');
 const portalLib = require('/lib/xp/portal');
 const jwtLib = require('/lib/jwt');
+const deviceLogin = require('/lib/deviceLogin');
 
 function redirectToAuthorizationEndpoint() {
     const idProviderConfig = configLib.getIdProviderConfig();
@@ -200,18 +201,39 @@ function generateRedirectUrl() {
 
 
 exports.handle401 = redirectToAuthorizationEndpoint;
-exports.get = handleAuthenticationResponse;
+
+exports.GET = function (req) {
+    const deviceResponse = deviceLogin.handleGet(req);
+    if (deviceResponse) {
+        return deviceResponse;
+    }
+    return handleAuthenticationResponse(req);
+};
+
+exports.POST = function (req) {
+    return deviceLogin.handlePost(req) || {status: 404};
+};
+
 exports.logout = logout;
 
 exports.autoLogin = function (req) {
     const idProviderConfig = configLib.getIdProviderConfig();
-    if (!idProviderConfig.jwksUri) {
-        return;
-    }
 
     const jwtToken = extractJwtToken(req, idProviderConfig);
 
     if (!jwtToken) {
+        requestLib.autoLoginFailed();
+        return;
+    }
+
+    if (deviceLogin.isSelfIssued(idProviderConfig, jwtToken)) {
+        if (!deviceLogin.accept(jwtToken, idProviderConfig)) {
+            requestLib.autoLoginFailed();
+        }
+        return;
+    }
+
+    if (!idProviderConfig.jwksUri) {
         requestLib.autoLoginFailed();
         return;
     }

--- a/src/main/resources/lib/deviceLogin.js
+++ b/src/main/resources/lib/deviceLogin.js
@@ -1,0 +1,313 @@
+const authLib = require('/lib/xp/auth');
+const configLib = require('/lib/config');
+const store = require('/lib/deviceStore');
+const deviceToken = require('/lib/deviceToken');
+const refreshStore = require('/lib/refreshStore');
+const portalLib = require('/lib/xp/portal');
+
+const DEVICE_CODE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
+const REFRESH_TOKEN_GRANT = 'refresh_token';
+const HANDLER_BEAN = 'com.enonic.app.oidcidprovider.handler.DeviceTokenHandler';
+
+const TOKEN_EXPIRES_IN = 3600;       // self-issued access token lifetime, seconds
+const DEVICE_CODE_EXPIRES_IN = 600;  // device / user code lifetime, seconds
+const DEVICE_POLL_INTERVAL = 5;      // minimum client poll interval, seconds
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function endpointSubPath(req) {
+    const contextPath = req.contextPath || '';
+    const path = req.path || '';
+    return path.indexOf(contextPath) === 0 ? path.substring(contextPath.length) : path;
+}
+
+function json(status, body, extraHeaders) {
+    const headers = {'Cache-Control': 'no-store'};
+    if (extraHeaders) {
+        Object.keys(extraHeaders).forEach(k => headers[k] = extraHeaders[k]);
+    }
+    return {status: status, contentType: 'application/json', body: JSON.stringify(body), headers: headers};
+}
+
+function oauthError(status, code, description) {
+    const body = {error: code};
+    if (description) {
+        body.error_description = description;
+    }
+    return json(status, body);
+}
+
+function htmlPage(title, bodyHtml) {
+    const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">` +
+                 `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+                 `<title>${escapeHtml(title)}</title>` +
+                 `<style>body{font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;` +
+                 `background:#f5f6f8;margin:0;padding:0;color:#333}` +
+                 `.card{max-width:420px;margin:8vh auto;background:#fff;border-radius:8px;` +
+                 `box-shadow:0 1px 4px rgba(0,0,0,.12);padding:32px}` +
+                 `h1{font-size:20px;margin:0 0 16px}` +
+                 `code{font-size:22px;letter-spacing:2px;background:#f0f1f3;padding:4px 8px;border-radius:4px;white-space:nowrap}` +
+                 `.codeline{text-align:center;margin:16px 0}` +
+                 `.detail{display:flex;margin:6px 0;font-size:14px}` +
+                 `.detail .k{flex:0 0 92px;color:#777}.detail .v{color:#222;word-break:break-word}` +
+                 `input[type=text]{font-size:18px;padding:8px;width:100%;box-sizing:border-box;` +
+                 `border:1px solid #ccc;border-radius:4px;letter-spacing:2px;text-transform:uppercase}` +
+                 `button{font-size:15px;padding:10px 18px;border:0;border-radius:4px;cursor:pointer;margin-top:16px}` +
+                 `.approve{background:#2c76e0;color:#fff}.deny{background:#e6e8eb;color:#333;margin-left:8px}` +
+                 `</style></head><body><div class="card">${bodyHtml}</div></body></html>`;
+    return {status: 200, contentType: 'text/html; charset=utf-8', body: html, headers: {'Cache-Control': 'no-store'}};
+}
+
+function escapeHtml(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function firstParam(value) {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function scopeList(scope) {
+    const scopes = String(scope || '').split(/\s+/).filter(s => s.length > 0);
+    return scopes.length ? scopes.join(', ') : '(none specified)';
+}
+
+// ---------------------------------------------------------------------------
+// Endpoints
+// ---------------------------------------------------------------------------
+
+// POST .../device/code  (RFC 8628 device authorization endpoint)
+function deviceAuthorization(req) {
+    const config = configLib.getIdProviderConfig();
+    const handler = __.newBean(HANDLER_BEAN);
+    const deviceCode = handler.generateDeviceCode();
+    const userCode = handler.generateUserCode();
+
+    store.createPending(config._idProviderName, {
+        deviceCode: deviceCode,
+        userCode: userCode,
+        clientId: req.params.client_id,
+        scope: req.params.scope,
+        audience: req.params.resource || '',
+        ttlSeconds: DEVICE_CODE_EXPIRES_IN,
+    });
+
+    const verificationUri = portalLib.idProviderUrl({idProvider: config._idProviderName, type: 'absolute'}) + '/device';
+    return json(200, {
+        device_code: deviceCode,
+        user_code: userCode,
+        verification_uri: verificationUri,
+        verification_uri_complete: verificationUri + '?user_code=' + encodeURIComponent(userCode),
+        expires_in: DEVICE_CODE_EXPIRES_IN,
+        interval: DEVICE_POLL_INTERVAL,
+    });
+}
+
+// POST .../token  (RFC 6749 token endpoint: device_code and refresh_token grants)
+function tokenEndpoint(req) {
+    const config = configLib.getIdProviderConfig();
+    switch (req.params.grant_type) {
+    case DEVICE_CODE_GRANT:
+        return deviceCodeGrant(req, config);
+    case REFRESH_TOKEN_GRANT:
+        return refreshTokenGrant(req, config);
+    default:
+        return oauthError(400, 'unsupported_grant_type');
+    }
+}
+
+// RFC 8628 device_code grant (polling).
+function deviceCodeGrant(req, config) {
+    const deviceCode = req.params.device_code;
+    if (!deviceCode) {
+        return oauthError(400, 'invalid_request', 'Missing device_code');
+    }
+
+    const result = store.poll(config._idProviderName, deviceCode, DEVICE_POLL_INTERVAL);
+
+    switch (result.state) {
+    case 'pending':
+        return oauthError(400, 'authorization_pending');
+    case 'slow_down':
+        return oauthError(400, 'slow_down');
+    case 'denied':
+        return oauthError(400, 'access_denied');
+    case 'approved': {
+        const grant = result.record;
+        const refreshToken = refreshStore.issue({
+            sub: grant.sub,
+            clientId: grant.clientId,
+            scope: grant.scope,
+            audience: grant.audience,
+        });
+        return tokenResponse(config, grant, refreshToken);
+    }
+    case 'expired':
+    default:
+        return oauthError(400, 'expired_token');
+    }
+}
+
+// RFC 6749 section 6 refresh_token grant.
+function refreshTokenGrant(req, config) {
+    const refreshToken = req.params.refresh_token;
+    if (!refreshToken) {
+        return oauthError(400, 'invalid_request', 'Missing refresh_token');
+    }
+
+    const grant = refreshStore.redeem(config._idProviderName, refreshToken);
+    if (!grant) {
+        return oauthError(400, 'invalid_grant', 'Invalid or expired refresh_token');
+    }
+    // RFC 6749 section 6: a public client must present the same client_id the grant was issued to.
+    if (req.params.client_id && grant.clientId && req.params.client_id !== grant.clientId) {
+        return oauthError(400, 'invalid_grant', 'client_id mismatch');
+    }
+
+    return tokenResponse(config, grant, grant.refreshToken);
+}
+
+function tokenResponse(config, grant, refreshToken) {
+    const token = deviceToken.mint(config, {
+        subject: grant.sub,
+        audience: grant.audience,
+        clientId: grant.clientId,
+        scope: grant.scope,
+        expiresInSeconds: TOKEN_EXPIRES_IN,
+    });
+    const body = {
+        access_token: token,
+        token_type: 'Bearer',
+        expires_in: TOKEN_EXPIRES_IN,
+        refresh_token: refreshToken,
+    };
+    if (grant.scope) {
+        body.scope = grant.scope;
+    }
+    return json(200, body);
+}
+
+// GET .../device  (human verification page = verification_uri)
+function verificationPage(req) {
+    const config = configLib.getIdProviderConfig();
+    const user = authLib.getUser();
+    if (!user) {
+        return {status: 401};
+    }
+
+    const userCode = firstParam(req.params.user_code);
+    if (!userCode) {
+        return htmlPage('Device sign-in', enterCodeForm(''));
+    }
+
+    const found = store.findByUserCode(config._idProviderName, userCode.toUpperCase());
+    if (!found || found.record.status !== 'pending') {
+        return htmlPage('Device sign-in', `<h1>Device sign-in</h1>` +
+                                           `<p>The code <code>${escapeHtml(userCode)}</code> is invalid or has expired.</p>` +
+                                           enterCodeForm(''));
+    }
+
+    return htmlPage('Confirm device sign-in', confirmForm(userCode.toUpperCase(), user, found.record));
+}
+
+// POST .../device  (approve / deny submission)
+function verificationSubmit(req) {
+    const config = configLib.getIdProviderConfig();
+    const user = authLib.getUser();
+    if (!user) {
+        return {status: 401};
+    }
+
+    const userCode = (firstParam(req.params.user_code) || '').toUpperCase();
+    const approve = firstParam(req.params.approve) === 'true';
+
+    const found = store.findByUserCode(config._idProviderName, userCode);
+    if (!found || found.record.status !== 'pending') {
+        return htmlPage('Device sign-in', `<h1>Device sign-in</h1><p>This code is invalid or has expired.</p>`);
+    }
+
+    store.resolve(config._idProviderName, found.deviceCode, approve, {sub: user.key}, DEVICE_CODE_EXPIRES_IN);
+
+    const message = approve
+        ? `<h1>You're all set</h1><p>The device has been approved. You can return to your application.</p>`
+        : `<h1>Request denied</h1><p>The device sign-in request was denied.</p>`;
+    return htmlPage('Device sign-in', message);
+}
+
+function enterCodeForm(userCode) {
+    return `<h1>Device sign-in</h1>` +
+           `<p>Enter the code shown by your application.</p>` +
+           `<form method="get" action="">` +
+           `<input type="text" name="user_code" value="${escapeHtml(userCode)}" placeholder="XXXX-XXXX" autofocus>` +
+           `<div><button class="approve" type="submit">Continue</button></div>` +
+           `</form>`;
+}
+
+function confirmForm(userCode, user, record) {
+    const application = record.clientId ? escapeHtml(record.clientId) : 'an unidentified client';
+    return `<h1>Confirm device sign-in</h1>` +
+           `<p>You are signed in as <strong>${escapeHtml(user.displayName || user.login)}</strong>.</p>` +
+           `<p>A device is requesting access using code:</p>` +
+           `<p class="codeline"><code>${escapeHtml(userCode)}</code></p>` +
+           `<div class="detail"><span class="k">Application</span><span class="v">${application}</span></div>` +
+           `<div class="detail"><span class="k">Permissions</span><span class="v">${escapeHtml(scopeList(record.scope))}</span></div>` +
+           `<p>Approve only if you started this sign-in and recognise this application.</p>` +
+           `<form method="post" action="">` +
+           `<input type="hidden" name="user_code" value="${escapeHtml(userCode)}">` +
+           `<button class="approve" type="submit" name="approve" value="true">Approve</button>` +
+           `<button class="deny" type="submit" name="approve" value="false">Deny</button>` +
+           `</form>`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function handlePost(req) {
+    switch (endpointSubPath(req)) {
+    case '/device/code':
+        return deviceAuthorization(req);
+    case '/token':
+        return tokenEndpoint(req);
+    case '/device':
+        return verificationSubmit(req);
+    default:
+        return null;
+    }
+}
+
+function handleGet(req) {
+    if (endpointSubPath(req) === '/device') {
+        return verificationPage(req);
+    }
+    return null;
+}
+
+function accept(token, config) {
+    const payload = deviceToken.verify(config, token);
+    if (!payload || !payload.sub) {
+        return false;
+    }
+
+    const parts = payload.sub.split(':');
+    if (parts.length < 3 || parts[0] !== 'user') {
+        return false;
+    }
+
+    const result = authLib.login({
+        user: parts.slice(2).join(':'),
+        idProvider: parts[1],
+        skipAuth: true,
+        scope: 'REQUEST',
+    });
+
+    return !!(result && result.authenticated);
+}
+
+exports.handlePost = handlePost;
+exports.handleGet = handleGet;
+exports.accept = accept;
+exports.isSelfIssued = deviceToken.isSelfIssued;

--- a/src/main/resources/lib/deviceLogin.js
+++ b/src/main/resources/lib/deviceLogin.js
@@ -131,7 +131,8 @@ function normalizeParams(req) {
 function deviceAuthorization(req) {
     const config = configLib.getIdProviderConfig();
 
-    // RFC 8628 section 3.1: client_id is required for public clients.
+    // client_id is required (RFC 8628 section 3.1). This app does no client authentication, so
+    // every device client is treated as public.
     const clientId = req.params.client_id;
     if (!clientId) {
         return oauthError(400, 'invalid_request', 'Missing client_id');

--- a/src/main/resources/lib/deviceLogin.js
+++ b/src/main/resources/lib/deviceLogin.js
@@ -92,6 +92,12 @@ function scopeList(scope) {
     return scopes.length ? scopes.join(', ') : '(none specified)';
 }
 
+// RFC 8707: `resource` may be repeated. Join multiple values into the space-separated audience the
+// token signer expands into multiple `aud` entries; a single value passes through unchanged.
+function resourceAudience(resource) {
+    return Array.isArray(resource) ? resource.join(' ') : (resource || '');
+}
+
 // ---------------------------------------------------------------------------
 // Endpoints
 // ---------------------------------------------------------------------------
@@ -99,6 +105,13 @@ function scopeList(scope) {
 // POST .../device/code  (RFC 8628 device authorization endpoint)
 function deviceAuthorization(req) {
     const config = configLib.getIdProviderConfig();
+
+    // RFC 8628 section 3.1: client_id is required for public clients.
+    const clientId = firstParam(req.params.client_id);
+    if (!clientId) {
+        return oauthError(400, 'invalid_request', 'Missing client_id');
+    }
+
     const handler = __.newBean(HANDLER_BEAN);
     const deviceCode = handler.generateDeviceCode();
     const userCode = handler.generateUserCode();
@@ -106,9 +119,9 @@ function deviceAuthorization(req) {
     store.createPending(config._idProviderName, {
         deviceCode: deviceCode,
         userCode: userCode,
-        clientId: req.params.client_id,
-        scope: req.params.scope,
-        audience: req.params.resource || '',
+        clientId: clientId,
+        scope: firstParam(req.params.scope),
+        audience: resourceAudience(req.params.resource),
         ttlSeconds: DEVICE_CODE_EXPIRES_IN,
     });
 

--- a/src/main/resources/lib/deviceLogin.js
+++ b/src/main/resources/lib/deviceLogin.js
@@ -4,10 +4,16 @@ const store = require('/lib/deviceStore');
 const deviceToken = require('/lib/deviceToken');
 const refreshStore = require('/lib/refreshStore');
 const portalLib = require('/lib/xp/portal');
+const contextLib = require('/lib/xp/context');
 
 const DEVICE_CODE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
 const REFRESH_TOKEN_GRANT = 'refresh_token';
 const HANDLER_BEAN = 'com.enonic.app.oidcidprovider.handler.DeviceTokenHandler';
+// Per-vhost audience, set via `mapping.<vhost>.context.deviceauth.audience` (copied into the
+// execution context by XP's ContextFilter). The issuer vhost stamps it on minted tokens; a resource
+// vhost requires it on verification. Unset -> tokens carry the client's `resource` and are accepted
+// regardless of audience (backward compatible).
+const AUDIENCE_ATTR = 'deviceauth.audience';
 
 const TOKEN_EXPIRES_IN = 3600;       // self-issued access token lifetime, seconds
 const DEVICE_CODE_EXPIRES_IN = 600;  // device / user code lifetime, seconds
@@ -98,6 +104,14 @@ function resourceAudience(resource) {
     return Array.isArray(resource) ? resource.join(' ') : (resource || '');
 }
 
+// Audiences this vhost issues / requires, from the deviceauth.audience context attribute -
+// whitespace-separated, like the JWT `aud`, OAuth `scope`, and the `resource`->`aud` path above.
+// Empty list when the vhost configures none.
+function configuredAudiences() {
+    const attrs = contextLib.get().attributes || {};
+    return String(attrs[AUDIENCE_ATTR] || '').split(/\s+/).filter(s => s.length > 0);
+}
+
 // Repeated query/form params arrive as arrays. Collapse every param to its first value so the
 // endpoints always see scalars; `resource` is kept intact (RFC 8707 permits repeats).
 function normalizeParams(req) {
@@ -127,12 +141,16 @@ function deviceAuthorization(req) {
     const deviceCode = handler.generateDeviceCode();
     const userCode = handler.generateUserCode();
 
+    // A vhost-configured audience (deployment authority) wins over the client-requested resource.
+    const configured = configuredAudiences();
+    const audience = configured.length ? configured.join(' ') : resourceAudience(req.params.resource);
+
     store.createPending(config._idProviderName, {
         deviceCode: deviceCode,
         userCode: userCode,
         clientId: clientId,
         scope: req.params.scope,
-        audience: resourceAudience(req.params.resource),
+        audience: audience,
         ttlSeconds: DEVICE_CODE_EXPIRES_IN,
     });
 
@@ -332,7 +350,8 @@ function handleGet(req) {
 }
 
 function accept(token, config) {
-    const payload = deviceToken.verify(config, token);
+    // A resource vhost may require a specific audience; unset -> accept any (backward compatible).
+    const payload = deviceToken.verify(config, token, configuredAudiences());
     if (!payload || !payload.sub) {
         return false;
     }

--- a/src/main/resources/lib/deviceLogin.js
+++ b/src/main/resources/lib/deviceLogin.js
@@ -39,25 +39,42 @@ function oauthError(status, code, description) {
     return json(status, body);
 }
 
+const STYLE =
+    `body{font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:#f5f6f8;margin:0;padding:0;color:#333}` +
+    `.card{max-width:420px;margin:8vh auto;background:#fff;border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,.12);padding:32px}` +
+    `h1{font-size:20px;margin:0 0 16px}` +
+    `code{font-size:22px;letter-spacing:2px;background:#f0f1f3;padding:4px 8px;border-radius:4px;white-space:nowrap}` +
+    `.codeline{text-align:center;margin:16px 0}` +
+    `.detail{display:flex;margin:6px 0;font-size:14px}` +
+    `.detail .k{flex:0 0 92px;color:#777}.detail .v{color:#222;word-break:break-word}` +
+    `input[type=text]{font-size:18px;padding:8px;width:100%;box-sizing:border-box;border:1px solid #ccc;border-radius:4px;letter-spacing:2px;text-transform:uppercase}` +
+    `button{font-size:15px;padding:10px 18px;border:0;border-radius:4px;cursor:pointer;margin-top:16px}` +
+    `.approve{background:#2c76e0;color:#fff}.deny{background:#e6e8eb;color:#333;margin-left:8px}`;
+
+// CSP style-src source pinned to the exact stylesheet above (computed from STYLE, so it never drifts).
+let styleCspSource = null;
+function styleCsp() {
+    if (!styleCspSource) {
+        styleCspSource = "'sha256-" + __.newBean(HANDLER_BEAN).sha256Base64(STYLE) + "'";
+    }
+    return styleCspSource;
+}
+
 function htmlPage(title, bodyHtml) {
     const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">` +
                  `<meta name="viewport" content="width=device-width, initial-scale=1">` +
                  `<title>${escapeHtml(title)}</title>` +
-                 `<style>body{font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;` +
-                 `background:#f5f6f8;margin:0;padding:0;color:#333}` +
-                 `.card{max-width:420px;margin:8vh auto;background:#fff;border-radius:8px;` +
-                 `box-shadow:0 1px 4px rgba(0,0,0,.12);padding:32px}` +
-                 `h1{font-size:20px;margin:0 0 16px}` +
-                 `code{font-size:22px;letter-spacing:2px;background:#f0f1f3;padding:4px 8px;border-radius:4px;white-space:nowrap}` +
-                 `.codeline{text-align:center;margin:16px 0}` +
-                 `.detail{display:flex;margin:6px 0;font-size:14px}` +
-                 `.detail .k{flex:0 0 92px;color:#777}.detail .v{color:#222;word-break:break-word}` +
-                 `input[type=text]{font-size:18px;padding:8px;width:100%;box-sizing:border-box;` +
-                 `border:1px solid #ccc;border-radius:4px;letter-spacing:2px;text-transform:uppercase}` +
-                 `button{font-size:15px;padding:10px 18px;border:0;border-radius:4px;cursor:pointer;margin-top:16px}` +
-                 `.approve{background:#2c76e0;color:#fff}.deny{background:#e6e8eb;color:#333;margin-left:8px}` +
-                 `</style></head><body><div class="card">${bodyHtml}</div></body></html>`;
-    return {status: 200, contentType: 'text/html; charset=utf-8', body: html, headers: {'Cache-Control': 'no-store'}};
+                 `<style>${STYLE}</style></head><body><div class="card">${bodyHtml}</div></body></html>`;
+    return {
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: html,
+        headers: {
+            'Cache-Control': 'no-store',
+            'Content-Security-Policy': `default-src 'none'; style-src ${styleCsp()}; form-action 'self'; base-uri 'none'; frame-ancestors 'none'`,
+            'Referrer-Policy': 'no-referrer',
+        },
+    };
 }
 
 function escapeHtml(value) {

--- a/src/main/resources/lib/deviceLogin.js
+++ b/src/main/resources/lib/deviceLogin.js
@@ -98,6 +98,17 @@ function resourceAudience(resource) {
     return Array.isArray(resource) ? resource.join(' ') : (resource || '');
 }
 
+// Repeated query/form params arrive as arrays. Collapse every param to its first value so the
+// endpoints always see scalars; `resource` is kept intact (RFC 8707 permits repeats).
+function normalizeParams(req) {
+    const src = req.params || {};
+    const out = {};
+    Object.keys(src).forEach(function (key) {
+        out[key] = key === 'resource' ? src[key] : firstParam(src[key]);
+    });
+    req.params = out;
+}
+
 // ---------------------------------------------------------------------------
 // Endpoints
 // ---------------------------------------------------------------------------
@@ -107,7 +118,7 @@ function deviceAuthorization(req) {
     const config = configLib.getIdProviderConfig();
 
     // RFC 8628 section 3.1: client_id is required for public clients.
-    const clientId = firstParam(req.params.client_id);
+    const clientId = req.params.client_id;
     if (!clientId) {
         return oauthError(400, 'invalid_request', 'Missing client_id');
     }
@@ -120,7 +131,7 @@ function deviceAuthorization(req) {
         deviceCode: deviceCode,
         userCode: userCode,
         clientId: clientId,
-        scope: firstParam(req.params.scope),
+        scope: req.params.scope,
         audience: resourceAudience(req.params.resource),
         ttlSeconds: DEVICE_CODE_EXPIRES_IN,
     });
@@ -228,7 +239,7 @@ function verificationPage(req) {
         return {status: 401};
     }
 
-    const userCode = firstParam(req.params.user_code);
+    const userCode = req.params.user_code;
     if (!userCode) {
         return htmlPage('Device sign-in', enterCodeForm(''));
     }
@@ -251,8 +262,8 @@ function verificationSubmit(req) {
         return {status: 401};
     }
 
-    const userCode = (firstParam(req.params.user_code) || '').toUpperCase();
-    const approve = firstParam(req.params.approve) === 'true';
+    const userCode = (req.params.user_code || '').toUpperCase();
+    const approve = req.params.approve === 'true';
 
     const found = store.findByUserCode(config._idProviderName, userCode);
     if (!found || found.record.status !== 'pending') {
@@ -299,10 +310,13 @@ function confirmForm(userCode, user, record) {
 function handlePost(req) {
     switch (endpointSubPath(req)) {
     case '/device/code':
+        normalizeParams(req);
         return deviceAuthorization(req);
     case '/token':
+        normalizeParams(req);
         return tokenEndpoint(req);
     case '/device':
+        normalizeParams(req);
         return verificationSubmit(req);
     default:
         return null;
@@ -311,6 +325,7 @@ function handlePost(req) {
 
 function handleGet(req) {
     if (endpointSubPath(req) === '/device') {
+        normalizeParams(req);
         return verificationPage(req);
     }
     return null;

--- a/src/main/resources/lib/deviceStore.js
+++ b/src/main/resources/lib/deviceStore.js
@@ -1,0 +1,116 @@
+const gridLib = require('/lib/xp/grid');
+
+const SIGNING_KEY = 'signingKey';
+
+function getMap(idProviderName) {
+    return gridLib.getMap(`com.enonic.app.oidcidprovider.deviceauth.${idProviderName}`);
+}
+
+function withUpdates(record, updates) {
+    const next = {
+        status: record.status,
+        userCode: record.userCode,
+        clientId: record.clientId,
+        scope: record.scope,
+        audience: record.audience,
+        sub: record.sub,
+        createdAt: record.createdAt,
+        lastPolledAt: record.lastPolledAt,
+    };
+    Object.keys(updates).forEach(function (key) {
+        next[key] = updates[key];
+    });
+    return next;
+}
+
+function createPending(idProviderName, params) {
+    const map = getMap(idProviderName);
+    const record = {
+        status: 'pending',
+        userCode: params.userCode,
+        clientId: params.clientId || '',
+        scope: params.scope || '',
+        audience: params.audience || '',
+        createdAt: Date.now(),
+        lastPolledAt: 0,
+    };
+    map.set({key: params.deviceCode, value: record, ttlSeconds: params.ttlSeconds});
+    map.set({key: `uc:${params.userCode}`, value: params.deviceCode, ttlSeconds: params.ttlSeconds});
+}
+
+function findByUserCode(idProviderName, userCode) {
+    const map = getMap(idProviderName);
+    const deviceCode = map.get(`uc:${userCode}`);
+    if (!deviceCode) {
+        return null;
+    }
+    const record = map.get(deviceCode);
+    return record ? {deviceCode: deviceCode, record: record} : null;
+}
+
+function resolve(idProviderName, deviceCode, approved, principal, ttlSeconds) {
+    const map = getMap(idProviderName);
+    return map.modify({
+        key: deviceCode,
+        ttlSeconds: ttlSeconds,
+        func: function (record) {
+            if (!record) {
+                return null;
+            }
+            if (record.status !== 'pending') {
+                return withUpdates(record, {});
+            }
+            return approved
+                ? withUpdates(record, {status: 'approved', sub: principal.sub})
+                : withUpdates(record, {status: 'denied'});
+        }
+    });
+}
+
+function poll(idProviderName, deviceCode, intervalSeconds) {
+    const map = getMap(idProviderName);
+    let result = {state: 'expired'};
+    map.modify({
+        key: deviceCode,
+        func: function (record) {
+            if (!record) {
+                result = {state: 'expired'};
+                return null;
+            }
+
+            const now = Date.now();
+            if (record.lastPolledAt && (now - record.lastPolledAt) < (intervalSeconds * 1000)) {
+                result = {state: 'slow_down'};
+                return withUpdates(record, {});
+            }
+
+            if (record.status === 'denied') {
+                result = {state: 'denied'};
+                return null;
+            }
+            if (record.status === 'approved') {
+                result = {state: 'approved', record: record};
+                return null;
+            }
+            result = {state: 'pending'};
+            return withUpdates(record, {lastPolledAt: now});
+        }
+    });
+    return result;
+}
+
+function getOrCreateSigningKey(idProviderName, generate) {
+    return getMap(idProviderName).modify({
+        key: SIGNING_KEY,
+        ttlSeconds: 0,
+        func: function (existing) {
+            return existing ? {secret: existing.secret, kid: existing.kid} : generate();
+        }
+    });
+}
+
+exports.createPending = createPending;
+exports.findByUserCode = findByUserCode;
+exports.resolve = resolve;
+exports.poll = poll;
+exports.getOrCreateSigningKey = getOrCreateSigningKey;

--- a/src/main/resources/lib/deviceStore.js
+++ b/src/main/resources/lib/deviceStore.js
@@ -78,12 +78,7 @@ function poll(idProviderName, deviceCode, intervalSeconds) {
                 return null;
             }
 
-            const now = Date.now();
-            if (record.lastPolledAt && (now - record.lastPolledAt) < (intervalSeconds * 1000)) {
-                result = {state: 'slow_down'};
-                return withUpdates(record, {});
-            }
-
+            // A resolved request is reported immediately; the rate-limit only throttles pending polls.
             if (record.status === 'denied') {
                 result = {state: 'denied'};
                 return null;
@@ -91,6 +86,12 @@ function poll(idProviderName, deviceCode, intervalSeconds) {
             if (record.status === 'approved') {
                 result = {state: 'approved', record: record};
                 return null;
+            }
+
+            const now = Date.now();
+            if (record.lastPolledAt && (now - record.lastPolledAt) < (intervalSeconds * 1000)) {
+                result = {state: 'slow_down'};
+                return withUpdates(record, {});
             }
             result = {state: 'pending'};
             return withUpdates(record, {lastPolledAt: now});

--- a/src/main/resources/lib/deviceToken.js
+++ b/src/main/resources/lib/deviceToken.js
@@ -1,0 +1,54 @@
+const store = require('/lib/deviceStore');
+
+const BEAN = 'com.enonic.app.oidcidprovider.handler.DeviceTokenHandler';
+
+const keyCache = {};
+
+function resolveKey(idProviderConfig) {
+    const name = idProviderConfig._idProviderName;
+    let key = keyCache[name];
+    if (!key) {
+        key = store.getOrCreateSigningKey(name, function () {
+            const handler = __.newBean(BEAN);
+            return {
+                secret: handler.generateDeviceCode(),
+                kid: `${name}-hs512-${String(handler.generateDeviceCode()).substring(0, 8)}`,
+            };
+        });
+        keyCache[name] = key;
+    }
+    return key;
+}
+
+function getIssuer(idProviderConfig) {
+    return `${app.name}:${idProviderConfig._idProviderName}`;
+}
+
+function mint(idProviderConfig, params) {
+    const key = resolveKey(idProviderConfig);
+    return __.newBean(BEAN).sign(
+        key.secret,
+        key.kid,
+        getIssuer(idProviderConfig),
+        params.subject,
+        params.audience || '',
+        params.clientId || '',
+        params.scope || '',
+        params.expiresInSeconds
+    );
+}
+
+function verify(idProviderConfig, token) {
+    const key = resolveKey(idProviderConfig);
+    const payload = __.newBean(BEAN).verify(token, key.secret, getIssuer(idProviderConfig), []);
+    return payload ? __.toNativeObject(payload) : null;
+}
+
+function isSelfIssued(idProviderConfig, token) {
+    const issuer = __.newBean(BEAN).peekIssuer(token);
+    return !!issuer && issuer === getIssuer(idProviderConfig);
+}
+
+exports.mint = mint;
+exports.verify = verify;
+exports.isSelfIssued = isSelfIssued;

--- a/src/main/resources/lib/deviceToken.js
+++ b/src/main/resources/lib/deviceToken.js
@@ -38,9 +38,9 @@ function mint(idProviderConfig, params) {
     );
 }
 
-function verify(idProviderConfig, token) {
+function verify(idProviderConfig, token, allowedAudience) {
     const key = resolveKey(idProviderConfig);
-    const payload = __.newBean(BEAN).verify(token, key.secret, getIssuer(idProviderConfig), []);
+    const payload = __.newBean(BEAN).verify(token, key.secret, getIssuer(idProviderConfig), allowedAudience || []);
     return payload ? __.toNativeObject(payload) : null;
 }
 

--- a/src/main/resources/lib/refreshStore.js
+++ b/src/main/resources/lib/refreshStore.js
@@ -1,0 +1,158 @@
+const authLib = require('/lib/xp/auth');
+const contextLib = require('/lib/context');
+const oidcLib = require('/lib/oidc');
+
+const HANDLER_BEAN = 'com.enonic.app.oidcidprovider.handler.DeviceTokenHandler';
+const PROFILE_SCOPE = 'deviceauth';
+
+const REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+const ROTATE_INTERVAL_MS = 54 * 60 * 1000; // 54 min
+const MAX_TOKENS_PER_CLIENT = 50;
+const UNKNOWN_BUCKET = '<unknown>';
+
+function bean() {
+    return __.newBean(HANDLER_BEAN);
+}
+
+function hashToken(rawToken) {
+    return oidcLib.generateChallenge(rawToken); // SHA-256, base64url
+}
+
+function mintToken(userKey) {
+    return bean().generateDeviceCode() + '.' + bean().base64UrlEncode(userKey);
+}
+
+function subjectOf(rawToken) {
+    const i = rawToken.indexOf('.');
+    if (i <= 0) {
+        return null;
+    }
+    try {
+        return bean().base64UrlDecode(rawToken.substring(i + 1));
+    } catch (e) {
+        return null;
+    }
+}
+
+function toArray(value) {
+    if (value == null) {
+        return [];
+    }
+    return Array.isArray(value) ? value : [value];
+}
+
+function readTokens(userKey) {
+    const profile = contextLib.runAsSu(() => authLib.getProfile({key: userKey, scope: PROFILE_SCOPE}));
+    return toArray(profile && profile.tokens);
+}
+
+function writeTokens(userKey, editor) {
+    contextLib.runAsSu(() => authLib.modifyProfile({
+        key: userKey,
+        scope: PROFILE_SCOPE,
+        editor: function (profile) {
+            return {tokens: editor(toArray(profile && profile.tokens))};
+        },
+    }));
+}
+
+function grantOf(entry, userKey, refreshToken) {
+    return {
+        sub: userKey,
+        clientId: entry.clientId,
+        scope: entry.scope,
+        audience: entry.audience,
+        refreshToken: refreshToken,
+    };
+}
+
+function newEntry(userKey, now, clientId, scope, audience, family, parent) {
+    const rawToken = mintToken(userKey);
+    return {
+        rawToken: rawToken,
+        entry: {
+            hash: hashToken(rawToken),
+            parent: parent || null,
+            family: family || bean().generateDeviceCode(),
+            clientId: clientId || '',
+            scope: scope || '',
+            audience: audience || '',
+            createdAt: now,
+            expiresAt: now + REFRESH_TOKEN_TTL_MS,
+            rotateAfter: now + ROTATE_INTERVAL_MS,
+        },
+    };
+}
+
+function isKnownClient(clientId) {
+    return false;
+}
+
+function bucketOf(clientId) {
+    return isKnownClient(clientId) ? clientId : UNKNOWN_BUCKET;
+}
+
+function issue(params) {
+    const now = Date.now();
+    const created = newEntry(params.sub, now, params.clientId, params.scope, params.audience, null, null);
+    const bucket = bucketOf(created.entry.clientId);
+    const byAge = (a, b) => a.createdAt - b.createdAt;
+    writeTokens(params.sub, tokens => {
+        const active = tokens.filter(t => t.expiresAt > now);
+        const others = active.filter(t => bucketOf(t.clientId) !== bucket);
+        const sameBucket = active.filter(t => bucketOf(t.clientId) === bucket).sort(byAge);
+        const keptSame = sameBucket.slice(Math.max(0, sameBucket.length - (MAX_TOKENS_PER_CLIENT - 1)));
+        return others.concat(keptSame, created.entry);
+    });
+    return created.rawToken;
+}
+
+function redeem(idProvider, rawToken) {
+    const userKey = subjectOf(rawToken);
+    if (!userKey || userKey.split(':')[1] !== idProvider) {
+        return null;
+    }
+    const h = hashToken(rawToken);
+    const now = Date.now();
+
+    const peek = readTokens(userKey).filter(t => t.hash === h)[0];
+    if (!peek || peek.expiresAt <= now) {
+        return null;
+    }
+    if (now < peek.rotateAfter) {
+        return grantOf(peek, userKey, rawToken);
+    }
+
+    let out = null;
+    writeTokens(userKey, tokens => {
+        const kept = tokens.filter(t => t.expiresAt > now);
+        const entry = kept.filter(t => t.hash === h)[0];
+        if (!entry) {
+            return kept;
+        }
+        const rotated = newEntry(userKey, now, entry.clientId, entry.scope, entry.audience, entry.family, entry.hash);
+        out = grantOf(entry, userKey, rotated.rawToken);
+        return kept.filter(t => t.hash !== entry.hash).concat(rotated.entry);
+    });
+    return out;
+}
+
+function listBySubject(userKey) {
+    const now = Date.now();
+    return readTokens(userKey).filter(t => t.expiresAt > now).map(t => ({
+        family: t.family,
+        clientId: t.clientId,
+        scope: t.scope,
+        createdAt: t.createdAt,
+        expiresAt: t.expiresAt,
+    }));
+}
+
+function revokeFamily(userKey, family) {
+    writeTokens(userKey, tokens => tokens.filter(t => t.family !== family));
+}
+
+exports.issue = issue;
+exports.redeem = redeem;
+exports.listBySubject = listBySubject;
+exports.revokeFamily = revokeFamily;

--- a/src/test/java/com/enonic/app/oidcidprovider/handler/DeviceTokenHandlerTest.java
+++ b/src/test/java/com/enonic/app/oidcidprovider/handler/DeviceTokenHandlerTest.java
@@ -1,0 +1,155 @@
+package com.enonic.app.oidcidprovider.handler;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.script.serializer.MapGenerator;
+import com.enonic.xp.script.serializer.MapSerializable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeviceTokenHandlerTest
+{
+    private static final String SECRET = "0123456789abcdef0123456789abcdef";
+
+    private final DeviceTokenHandler handler = new DeviceTokenHandler();
+
+    @Test
+    void sign_and_verify_roundtrip()
+    {
+        final String token =
+            handler.sign( SECRET, "myidp-hs512", "app:myidp", "user:myidp:john", "https://api.example.com", "cli", "openid", 3600 );
+
+        final Map<String, Object> payload = serialize( handler.verify( token, SECRET, "app:myidp", List.of( "https://api.example.com" ) ) );
+
+        assertNotNull( payload );
+        assertEquals( "user:myidp:john", payload.get( "sub" ) );
+        assertEquals( "app:myidp", payload.get( "iss" ) );
+        assertEquals( "cli", payload.get( "client_id" ) );
+    }
+
+    @Test
+    void verify_fails_with_wrong_secret()
+    {
+        final String token = handler.sign( SECRET, "k", "app:myidp", "john", "aud", "cli", "openid", 3600 );
+        assertNull( handler.verify( token, "another-secret-another-secret-32", "app:myidp", List.of() ) );
+    }
+
+    @Test
+    void verify_fails_with_wrong_issuer()
+    {
+        final String token = handler.sign( SECRET, "k", "app:myidp", "john", "aud", "cli", "openid", 3600 );
+        assertNull( handler.verify( token, SECRET, "app:other", List.of() ) );
+    }
+
+    @Test
+    void verify_fails_when_audience_not_allowed()
+    {
+        final String token = handler.sign( SECRET, "k", "app:myidp", "john", "aud-a", "cli", "openid", 3600 );
+        assertNull( handler.verify( token, SECRET, "app:myidp", List.of( "aud-b" ) ) );
+    }
+
+    @Test
+    void verify_fails_when_expired()
+    {
+        final String token = handler.sign( SECRET, "k", "app:myidp", "john", "aud", "cli", "openid", -10 );
+        assertNull( handler.verify( token, SECRET, "app:myidp", List.of() ) );
+    }
+
+    @Test
+    void peek_issuer_does_not_require_verification()
+    {
+        final String token = handler.sign( SECRET, "k", "app:myidp", "john", "aud", "cli", "openid", 3600 );
+        assertEquals( "app:myidp", handler.peekIssuer( token ) );
+        assertNull( handler.peekIssuer( "not-a-jwt" ) );
+    }
+
+    @Test
+    void generated_codes_are_unique_and_well_formed()
+    {
+        assertTrue( handler.generateUserCode().matches( "[BCDFGHJKLMNPQRSTVWXZ]{4}-[BCDFGHJKLMNPQRSTVWXZ]{4}" ) );
+        assertNotEquals( handler.generateDeviceCode(), handler.generateDeviceCode() );
+    }
+
+    private static Map<String, Object> serialize( final MapSerializable serializable )
+    {
+        if ( serializable == null )
+        {
+            return null;
+        }
+        final TestMapGenerator generator = new TestMapGenerator();
+        serializable.serialize( generator );
+        return generator.map;
+    }
+
+    /**
+     * Minimal MapGenerator that captures a flat object into a Map for assertions.
+     */
+    private static final class TestMapGenerator
+        implements MapGenerator
+    {
+        private final java.util.Map<String, Object> map = new java.util.HashMap<>();
+
+        @Override
+        public MapGenerator map( final String key )
+        {
+            return this;
+        }
+
+        @Override
+        public MapGenerator map()
+        {
+            return this;
+        }
+
+        @Override
+        public MapGenerator end()
+        {
+            return this;
+        }
+
+        @Override
+        public MapGenerator array( final String key )
+        {
+            return this;
+        }
+
+        @Override
+        public MapGenerator array()
+        {
+            return this;
+        }
+
+        @Override
+        public MapGenerator value( final Object value )
+        {
+            return this;
+        }
+
+        @Override
+        public MapGenerator value( final String key, final Object value )
+        {
+            this.map.put( key, value );
+            return this;
+        }
+
+        @Override
+        public MapGenerator rawValue( final Object value )
+        {
+            return this;
+        }
+
+        @Override
+        public MapGenerator rawValue( final String key, final Object value )
+        {
+            this.map.put( key, value );
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**THIS IS AN EXPERIMENTAL FEATURE!**
 
Adds **browserless CLI / device login** (OAuth 2.0 Device Authorization Grant, RFC 8628) to the OIDC id provider, implemented **entirely within the app** — no XP core dependency and no configuration. The human-approval step reuses the existing interactive login; the app issues, verifies and refreshes its own self-issued access tokens.

## Endpoints

Served by the id provider controller via method dispatch, clear of the reserved `login`/`logout` functions; the existing OAuth callback on `exports.GET` is untouched (uppercase `GET`/`POST` exports per XP 8).

| Endpoint | Purpose |
|---|---|
| `POST .../device/code` | device authorization → `device_code`, `user_code`, `verification_uri[_complete]`, `expires_in`, `interval` |
| `GET/POST .../device` | human verification + approval page (shows the requesting client and scopes) |
| `POST .../token` | `grant_type=urn:ietf:params:oauth:grant-type:device_code` (polling) and `grant_type=refresh_token` |

`verification_uri` is built from `portal.idProviderUrl()`, so it follows the vhost, scheme and any reverse-proxy forwarding.

## Access token

Self-issued **HS512** JWT following RFC 9068 (`typ=at+jwt`, `kid` header; claims `iss`, `sub` = full `PrincipalKey`, `aud`, `exp`, `iat`, `jti`, `client_id`, `scope`). Symmetric signing is correct here because the issuer and verifier are the same id provider. Verification is **issuer-pinned** and never trusts the token's `alg` header. The id provider is derived from `sub`. The token `aud` comes from the request `resource` (RFC 8707); optional claims are omitted when empty.

`autoLogin` validates a self-issued bearer (issuer-pinned HS512) and logs the principal in, independently of the external JWKS path.

## Refresh tokens

Durable, stored **hashed** in the owning user's profile (scope `deviceauth`) — nothing usable at rest, and they survive a cluster restart. The opaque token embeds its subject base64url-encoded (`<random>.<base64url(PrincipalKey)>`), so the owning profile is located without scanning and the token stays URL-safe. Redemption reuses the token while the access token is still fresh and **rotates it lazily** (at most ~one profile write per hour per device), pruning expired entries on the same write. Active tokens are **capped per bucket** — a `client_id` gets its own bucket, and every unrecognised client shares one `<unknown>` bucket — so spraying `client_id`s cannot grow the set unbounded; the oldest is evicted past the cap.

## Signing key & state

There is **no configured secret**. The HS512 signing key (`{secret, kid}`) is generated **once per cluster** and shared through the id provider's grid map (`deviceauth.<idp>`) via an atomic read-or-add under a reserved `signingKey` entry with **no expiry**, cached per JVM. Nothing is written to disk. A full cluster restart drops the key and a fresh one is generated (with a new random `kid` suffix); previously issued access tokens then stop verifying, but a refresh token (held in the durable profile) still mints a fresh access token under the new key.

Pending device requests live in the same grid map with a TTL and atomic, single-use consumption of approved codes.

## Configuration

**None.** Device login is always available for the id provider — the approval step still requires the user to authenticate and approve, so an unwanted flow cannot mint a token. The access-token TTL (1h), device-code TTL (10m), poll interval (5s), refresh-token TTL (90d) and per-client cap (50) are fixed in code.

## RFCs

8628 (device grant), 6749 / 6750 (token endpoint / bearer), 7519 / 7515 / 7518 (JWT / JWS / HS512), 9068 (`at+jwt`), 8707 (`resource` → `aud`).

## Tests

`DeviceTokenHandlerTest` covers sign/verify round-trip, wrong-secret / wrong-issuer / expiry rejection, issuer peeking, and code generation. `./gradlew build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5hnqWHpyfUaA3yV93msZq
