### PR TITLE
Device login: issue refresh token only for offline_access

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ projectName = oidcidprovider
 # XP App values
 appName = com.enonic.app.oidcidprovider
 version = 5.1.0-SNAPSHOT
-xpVersion = 8.0.0-B5
+xpVersion = 8.0.2
 
 # Settings for publishing to a Maven repo
 group = com.enonic.app

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-lib-http-client = "4.0.0-B1"
+lib-http-client = "4.0.0"
 java-jwt = "4.5.2"
 jwks-rsa = "0.24.1"
 jackson-databind = "2.21.3"

--- a/src/main/resources/lib/deviceLogin.js
+++ b/src/main/resources/lib/deviceLogin.js
@@ -8,6 +8,7 @@ const contextLib = require('/lib/xp/context');
 
 const DEVICE_CODE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
 const REFRESH_TOKEN_GRANT = 'refresh_token';
+const OFFLINE_ACCESS_SCOPE = 'offline_access';
 const HANDLER_BEAN = 'com.enonic.app.oidcidprovider.handler.DeviceTokenHandler';
 // Per-vhost audience, set via `mapping.<vhost>.context.deviceauth.audience` (copied into the
 // execution context by XP's ContextFilter). The issuer vhost stamps it on minted tokens; a resource
@@ -197,12 +198,15 @@ function deviceCodeGrant(req, config) {
         return oauthError(400, 'access_denied');
     case 'approved': {
         const grant = result.record;
-        const refreshToken = refreshStore.issue({
+        // Mint a refresh token (a durable profile write) only when the client asked for
+        // offline_access (OIDC Core); otherwise return an access token alone.
+        const offline = String(grant.scope || '').split(/\s+/).indexOf(OFFLINE_ACCESS_SCOPE) !== -1;
+        const refreshToken = offline ? refreshStore.issue({
             sub: grant.sub,
             clientId: grant.clientId,
             scope: grant.scope,
             audience: grant.audience,
-        });
+        }) : null;
         return tokenResponse(config, grant, refreshToken);
     }
     case 'expired':
@@ -242,8 +246,10 @@ function tokenResponse(config, grant, refreshToken) {
         access_token: token,
         token_type: 'Bearer',
         expires_in: TOKEN_EXPIRES_IN,
-        refresh_token: refreshToken,
     };
+    if (refreshToken) {
+        body.refresh_token = refreshToken;
+    }
     if (grant.scope) {
         body.scope = grant.scope;
     }


### PR DESCRIPTION
## Summary

Follow-up to #265. The device grant now mints a refresh token **only when the
client requests the `offline_access` scope** (OIDC Core §11). Without it, the
token response carries an access token alone and nothing is persisted for that
login.

## Behavior

| Requested scope | Response |
|---|---|
| `openid` | access token only — no `refresh_token`, no profile write |
| `openid offline_access` | access token + refresh token (as before) |

The `refresh_token` grant is unchanged. Net effect: least-privilege by default —
only clients that need silent renewal opt in and incur durable refresh-token state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5hnqWHpyfUaA3yV93msZq
