### PR TITLE
GraalJS Compatibility #277

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     testImplementation( platform( libs.junit.bom ) )
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -38,16 +37,9 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-check.dependsOn testGraalJs
 
 jacocoTestReport {
     reports {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation( platform( libs.junit.bom ) )
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -36,6 +37,17 @@ repositories {
 test {
     useJUnitPlatform()
 }
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+check.dependsOn testGraalJs
 
 jacocoTestReport {
     reports {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ projectName = oidcidprovider
 # XP App values
 appName = com.enonic.app.oidcidprovider
 version = 5.1.0-SNAPSHOT
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 
 # Settings for publishing to a Maven repo
 group = com.enonic.app

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.enonic.xp.settings") version "4.1.0"
+    id("com.enonic.xp.settings") version "4.2.0"
 }
 
 rootProject.name = projectName

--- a/src/main/java/com/enonic/app/oidcidprovider/OIDCUtils.java
+++ b/src/main/java/com/enonic/app/oidcidprovider/OIDCUtils.java
@@ -109,6 +109,11 @@ public class OIDCUtils
         return JWT.create().withPayload( message ).sign( Algorithm.HMAC256( clientSecret ) );
     }
 
+    public String base64Encode( final String value )
+    {
+        return Base64.getEncoder().encodeToString( value.getBytes( StandardCharsets.UTF_8 ) );
+    }
+
     @Override
     public void initialize( final BeanContext beanContext )
     {

--- a/src/main/resources/lib/oidc.js
+++ b/src/main/resources/lib/oidc.js
@@ -87,7 +87,7 @@ function requestIDToken(params) {
     case 'basic':
         headers = {
             'Authorization': 'Basic ' +
-                             Java.type('java.util.Base64').getEncoder().encodeToString((clientId + ':' + clientSecret).getBytes())
+                             __.newBean('com.enonic.app.oidcidprovider.OIDCUtils').base64Encode(clientId + ':' + clientSecret)
         };
         break;
     case 'jwt':

--- a/src/test/java/com/enonic/app/oidcidprovider/lib/OidcTest.java
+++ b/src/test/java/com/enonic/app/oidcidprovider/lib/OidcTest.java
@@ -1,0 +1,26 @@
+package com.enonic.app.oidcidprovider.lib;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.testing.ScriptTestSupport;
+
+public class OidcTest
+    extends ScriptTestSupport
+{
+    private void run( final String function )
+    {
+        runFunction( "/lib/oidc-test.js", function );
+    }
+
+    @Test
+    public void testBasicAuthEncodesCredentials()
+    {
+        run( "testBasicAuthEncodesCredentials" );
+    }
+
+    @Test
+    public void testBasicAuthEncodesCredentialsAsUtf8()
+    {
+        run( "testBasicAuthEncodesCredentialsAsUtf8" );
+    }
+}

--- a/src/test/resources/lib/oidc-test.js
+++ b/src/test/resources/lib/oidc-test.js
@@ -1,0 +1,44 @@
+const test = require('/lib/xp/testing');
+const testUtils = require('/testUtils');
+
+let capturedRequest = null;
+
+testUtils.mockAndGetUpdaterFunc('/lib/http-client', {
+    request: (request) => {
+        capturedRequest = request;
+        return { status: 500 };
+    },
+});
+
+const oidc = require('/lib/oidc');
+
+function tokenParams(extra) {
+    const params = {
+        issuer: 'https://provider.example.com',
+        tokenUrl: 'https://provider.example.com/token',
+        clientId: 'my-client',
+        clientSecret: 's3cr3t',
+        redirectUri: 'https://app.example.com/callback',
+        nonce: 'nonce-value',
+        code: 'auth-code',
+        idProviderName: 'oidc',
+    };
+    Object.keys(extra || {}).forEach(key => { params[key] = extra[key]; });
+    return params;
+}
+
+exports.testBasicAuthEncodesCredentials = () => {
+    capturedRequest = null;
+    const result = oidc.requestIDToken(tokenParams({ method: 'basic' }));
+
+    test.assertEquals(500, result.status);
+    test.assertEquals('Basic bXktY2xpZW50OnMzY3IzdA==', capturedRequest.headers.Authorization);
+};
+
+exports.testBasicAuthEncodesCredentialsAsUtf8 = () => {
+    capturedRequest = null;
+    const result = oidc.requestIDToken(tokenParams({ method: 'basic', clientId: 'user', clientSecret: 'pÿ€' }));
+
+    test.assertEquals(500, result.status);
+    test.assertEquals('Basic dXNlcjpww7/igqw=', capturedRequest.headers.Authorization);
+};


### PR DESCRIPTION
Fixes #277

## What

`basic` client authentication built its `Authorization` header with

```js
Java.type('java.util.Base64').getEncoder().encodeToString((clientId + ':' + clientSecret).getBytes())
```

`getBytes()` is a `java.lang.String` method, but `clientId + ':' + clientSecret` is a **JS**
string. GraalJS converts Java strings and boxed primitives into JS primitives that carry no Java
methods, so on GraalJS this throws on an auth path:

```
TypeError: ((clientId + ":") + clientSecret).getBytes is not a function
```

The encoding now goes through a new `OIDCUtils.base64Encode`, which also makes the charset
explicit (**UTF-8**) instead of relying on the platform default that the no-arg `getBytes()` used.
`base64Encode` uses the standard (padded) encoder, matching the previous `Base64.getEncoder()`.

## Tested on both engines

The JS tests now run once per script engine — Nashorn via `test` and GraalJS via `testGraalJs`,
both wired into `check`, mirroring `enonic/lib-sql#154`. A new `OidcTest` mocks `/lib/http-client`,
drives `requestIDToken({ method: 'basic', ... })`, and asserts the `Authorization` header — once
with ASCII credentials and once with a multi-byte secret to pin the UTF-8 encoding.

Reverting only the `oidc.js` line to the old `.getBytes()` form turns the two new tests red on
`testGraalJs` (with the `TypeError` above) while `test` stays green — the divergence the second
engine exists to catch.

Against a local build of enonic/xp#12198 (`publishToMavenLocal`, GraalVM CE 25):

```
test         41 tests, 0 failed
testGraalJs  41 tests, 0 failed
```

## Note on `xpVersion`

The bump to `8.1.0-SNAPSHOT` (and `enonicRepo('dev')`) is required by the `testGraalJs` harness,
not by the fix — the fix alone is green on Nashorn under `8.0.2`.

`ScriptRunnerSupport` (the `@TestFactory` base class used here by `InitIDProviderTest`) closed the
script executor during test discovery, so on GraalJS those factory tests fail with
`IllegalStateException` / `PolyglotEngineException` regardless of this app's code. That is fixed in
enonic/xp#12198, but the `8.1.0-SNAPSHOT` currently on `repo.enonic.com/dev` still carries the old
`ScriptRunnerSupport`. So on **CI** right now:

- `test` (Nashorn) — green;
- `testGraalJs` — `41 tests, 2 failed`, and the only two failures are the pre-existing
  `InitIDProviderTest > js()` factory tests hitting the published-snapshot gap. The two new
  `OidcTest` cases (which use `ScriptTestSupport`, not the factory) pass on both engines even on CI.

**CI `testGraalJs` stays red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is
published.** Holding this as a draft until then.